### PR TITLE
standardise pathing, add streamlit wrapper for pdfMain

### DIFF
--- a/ChromaDB/ingestPdf.py
+++ b/ChromaDB/ingestPdf.py
@@ -1,8 +1,16 @@
 from langchain.vectorstores import Chroma
 from client import persistent_client, embeddings
-from pdfMain import pdfMain
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from concurrent.futures import ThreadPoolExecutor
+
+import sys, os
+print("path of pdfPage", sys.path[0])
+workingDirectory = os.getcwd()
+
+if workingDirectory not in sys.path: sys.path.append(workingDirectory) 
+
+from pdfMain import pdfMainST
+
 
 def clearCollection():
     try:
@@ -20,7 +28,7 @@ def pdfUpload(listOfPdfs):
     issues = []
     for file in listOfPdfs:
         try:
-            sectionsByFile.append((pdfMain(file, file.name),file.name))
+            sectionsByFile.append((pdfMainST(file),file.name))
         except Exception as e:
             issues.append((e, file.name))
     text_splitter = RecursiveCharacterTextSplitter(

--- a/pages/4_pdfPage.py
+++ b/pages/4_pdfPage.py
@@ -1,15 +1,19 @@
 import pandas as pd
 import streamlit as st
-import sys
-import os
-
-sys.path.append('ChromaDB/')
 from concurrent.futures import as_completed
 from time import sleep
 from stqdm import stqdm
 import asyncio
-from ingestPdf import pdfUpload
 
+import sys, os
+# For streamlit the parent directory will the folder in which your root page is at. And this directory will also 
+# be your default working directory
+workingDirectory = os.getcwd()
+print(workingDirectory)
+chromaDirectory = os.path.join(workingDirectory, "ChromaDB")
+sys.path.append(chromaDirectory)
+
+from ingestPdf import pdfUpload
 
 st.header('PDF Analysis')
 

--- a/pdfMain.py
+++ b/pdfMain.py
@@ -10,8 +10,11 @@ from pdfReferenceRMV import removeReference
 from pdfSections import aggregateSpansToSections
 import fitz
 
-def pdfMain(uploaded_pdf, fileName):
+def pdfMainST(uploaded_pdf):
     doc = fitz.open(stream=uploaded_pdf.read(), filetype="pdf")
+    return pdfMain(doc, uploaded_pdf.name)
+
+def pdfMain(doc, fileName):
     doc, pgNo = removeReference(doc, fileName)
     txtpgs = [pg.get_textpage() for pg in doc]
     txtpgs = txtpgs[0:pgNo]


### PR DESCRIPTION
**Issue:** Pathing issues arise due to differences in how the parent directory is defined when a python script is run through streamlit as compared to simply running it directly.

**To resolve:** whenever a path needs to be appended to sys, append the absolute path. But to ensure it is consistent, the abs path will be constructed using os.path.join(os.getcwd(), “someSubdirectory”)