### PR TITLE
improve and integrate excel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ ChromaDB/__pycache__/
 data/
 
 .env
+
+output/

--- a/ChromaDB/filterConstants.py
+++ b/ChromaDB/filterConstants.py
@@ -1,0 +1,64 @@
+from langchain.chat_models import ChatOllama
+from langchain.output_parsers.structured import StructuredOutputParser, ResponseSchema
+from langchain.output_parsers import OutputFixingParser
+from langchain.prompts import (
+    ChatPromptTemplate,
+    SystemMessagePromptTemplate,
+    HumanMessagePromptTemplate,
+    PromptTemplate
+)
+from langchain.chat_models import ChatOllama
+chat = ChatOllama(model='llama2', temperature=0)
+import os 
+os.environ['LANGCHAIN_TRACING'] = 'false'
+
+from langchain.llms import Ollama
+llm = Ollama(temperature=0)
+
+# from langchain.chat_models import ChatOpenAI
+# chat = ChatOpenAI(temperature=0, model_name='gpt-3.5-turbo')
+
+system_template = '''
+Use the following pieces of context to answer the question.
+If you don't know the answer, just say that you don't know, don't try to make up an answer. 
+Use three sentences maximum and keep the answer as concise as possible.
+'''
+system_prompt = SystemMessagePromptTemplate.from_template(system_template)
+
+human_template = '''
+Context:
+    Title: {title}
+    Abstract: {abstract}
+
+Question: {question}\n
+{format_instructions}
+'''
+human_prompt = HumanMessagePromptTemplate.from_template(human_template)
+
+response_schemas = [
+  ResponseSchema(name="answer", description="a Yes or No answer", type="string"),
+  ResponseSchema(name="explanation", description="Explanation on why it is or it isn't relevant", type="string")
+]
+excel_parser = StructuredOutputParser.from_response_schemas(response_schemas)
+
+chat_prompt = ChatPromptTemplate(
+    messages=[system_prompt, human_prompt], 
+    partial_variables={
+        "format_instructions":excel_parser.get_format_instructions(),
+    }
+)
+
+output_fixer = OutputFixingParser.from_llm(parser=excel_parser, llm=llm)
+
+retry_message = """
+[INST]
+  <<SYS>>
+  The output has format JSONDecodeError preventing it from being parsed into a json object. Please help to correct it.
+  Error: 
+  {error}
+  Current Output:
+  {output}
+  <</SYS>>
+[/INST]
+"""
+retry_prompt = PromptTemplate.from_template(retry_message)

--- a/ChromaDB/filterExcel.py
+++ b/ChromaDB/filterExcel.py
@@ -1,0 +1,61 @@
+import sys, os
+workingDirectory = os.getcwd()
+sys.path.append(workingDirectory)
+
+from filterConstants import chat, chat_prompt, excel_parser, retry_prompt, output_fixer
+import pandas as pd
+from json.decoder import JSONDecodeError
+from concurrent.futures import ThreadPoolExecutor
+
+def correctFormatToJson(result_content, numTries, error_message):
+  if numTries > 3:
+     return None
+  else:
+    try:
+      jsonResult = output_fixer.parse_with_prompt(result_content, retry_prompt.format_prompt(error=error_message, output=result_content))
+    except Exception as e:
+      jsonResult = correctFormatToJson(result_content, numTries+1, error_message) 
+    return jsonResult
+
+def createTask(doi, title, abstract, query):
+  request = chat_prompt.format_prompt(title=title, abstract=abstract, question=query).to_messages()
+  result = chat(request)
+  try:
+    jsonOutput = excel_parser.parse(result.content)
+  except JSONDecodeError as e: # UNCATCHED ERROR HERE
+    jsonOutput = correctFormatToJson(result.content, 1, str(e))
+  return (doi, title, abstract, result.content, jsonOutput)
+
+def filterExcel(fileName, query):
+  df = pd.read_excel(fileName).dropna(how='all')[['DOI','TITLE','ABSTRACT']].iloc[:20]
+  executor = ThreadPoolExecutor(max_workers=2)
+  futures = []
+  for _, row in df.iterrows():
+      doi, title, abstract = row
+      futures.append(executor.submit(createTask, doi, title, abstract, query))
+  return (executor, futures)
+
+def getOutputDF(dfOut):
+    json_exists = dfOut["jsonOutput"].isna()
+    dfOut.loc[json_exists, 'prediction'] = dfOut.loc[json_exists, "jsonOutput"].apply(lambda x: x.get('answer'))
+    dfOut.loc[json_exists, 'justification_for_relevancy'] =dfOut.loc[json_exists, "jsonOutput"].apply(lambda x: x.get('explanation'))
+    
+    return dfOut
+
+# # FOR TESTING
+# executor, futures = filterExcel("data/combined.xlsx",  "Is the article about Food.")
+# from concurrent.futures import as_completed
+# from tqdm import tqdm
+# issues = []
+# results = []
+# with tqdm(total=len(futures)) as pbar:
+#     for future in as_completed(futures):
+#         row = future.result()
+#         results.append(row)
+#         pbar.update(1)
+
+# dfOut = pd.DataFrame(results, columns = ["DOI","TITLE","ABSTRACT","llmOutput", "jsonOutput"])
+# dfOut['prediction'] = dfOut["jsonOutput"].apply(lambda x: x['answer'])
+# dfOut['justification_for_relevancy'] = dfOut["jsonOutput"].apply(lambda x: x['explanation'])
+# dfOut.to_excel("test_output_pfa.xlsx")
+# print()


### PR DESCRIPTION
Update prompt to handle hallucination(saying yes even though it is definitely a no)—likely reason: llama2-7b cannot handle sophisticated system messages/instructions. Instructions are now much more simplified.

But since now the instructions can't direct the formatting. It mandates having formatting instructions after the question in the prompt.

The model has at most 3 tries to get the json formatting correct, else only the raw output from the model is returned.

Currently, there is a bug that isn't JsonDecodeError that is uncaptured and needs to be handled. The bug is not always reproducible due to the randomness of LLMs